### PR TITLE
fix: Correct contexts names for the org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,9 +359,9 @@ workflows:
     jobs:
       - save_and_restore_cache
       - contexts:
-          context: org-global
+          context: org-global-reality-checker
       - multi-contexts:
-          context: individual-local
+          context: individual-local-reality-checker
       - write_workspace
       - read_workspace:
           requires:


### PR DESCRIPTION
No Jira

This may have not worked since we rebuilt k9s last year?